### PR TITLE
Add deprecation warnings for string inputs

### DIFF
--- a/src/copairs/matching.py
+++ b/src/copairs/matching.py
@@ -2,6 +2,7 @@
 
 import re
 import logging
+import warnings
 import itertools
 from copy import copy
 from math import comb
@@ -519,8 +520,18 @@ def find_pairs(
 
 def _validate(sameby, diffby):
     if isinstance(sameby, str):
+        warnings.warn(
+            "Passing strings to 'sameby' is deprecated and will be removed in v0.5.3.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         sameby = (sameby,)
     if isinstance(diffby, str):
+        warnings.warn(
+            "Passing strings to 'diffby' is deprecated and will be removed in v0.5.3.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         diffby = (diffby,)
 
     if not (len(sameby) or len(diffby)):

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -127,7 +127,8 @@ def test_raise_no_params():
 
 def test_validate_string_inputs():
     """_validate should convert string inputs to tuples."""
-    sameby, diffby = _validate("c", "p")
+    with pytest.deprecated_call():
+        sameby, diffby = _validate("c", "p")
     assert sameby == ("c",)
     assert diffby == ("p",)
 

--- a/tests/test_matching_multilabel.py
+++ b/tests/test_matching_multilabel.py
@@ -1,6 +1,7 @@
 """Tests for the multilabel matching implementation."""
 
 import pandas as pd
+import pytest
 
 from tests.helpers import simulate_random_plates
 from copairs.matching import find_pairs_multilabel
@@ -160,7 +161,8 @@ def test_accepts_string_inputs():
     dframe = dframe.groupby(["p", "w"])["c"].unique().reset_index()
 
     gt_pairs = get_naive_pairs(dframe, [sameby], [diffby], multilabel_col)
-    vals = find_pairs_multilabel(dframe, sameby, diffby, multilabel_col)
+    with pytest.deprecated_call():
+        vals = find_pairs_multilabel(dframe, sameby, diffby, multilabel_col)
     if multilabel_col == sameby:
         vals = vals[0]
     vals = pd.DataFrame(vals, columns=["index_x", "index_y"])


### PR DESCRIPTION
- add deprecation warning for passing strings to `sameby` or `diffby`
- update tests to expect a `DeprecationWarning`